### PR TITLE
Fix RegisterContract arity in smart contract guide

### DIFF
--- a/src/content/docs/How To/smart contract development.mdx
+++ b/src/content/docs/How To/smart contract development.mdx
@@ -164,7 +164,7 @@ var ContractWasm []byte
 
 func TestContract(t *testing.T) {
   ct := test_utils.NewContractTest()
-  ct.RegisterContract("vsccontractid", ContractWasm)
+  ct.RegisterContract("vsccontractid", "hive:someone", ContractWasm)
   ct.Deposit("hive:someone", 1000, ledgerDb.AssetHive) // deposit 1 HIVE
   ct.Deposit("hive:someone", 1000, ledgerDb.AssetHbd) // deposit 1 HBD
 


### PR DESCRIPTION
The smart-contract-development how-to page calls RegisterContract with 2 args (id, wasm). The References/sdk page correctly uses 3 args (id, owner, wasm), which is the real signature.