### PR TITLE
docs: align chains and validation mechanism with current codebase

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig({
         starlightLlmsTxt({
           projectName: 'Magi',
           description:
-            "Magi (formerly known as VSC, Virtual Smart Chain) is a Hive-based Layer-2 protocol for cross-chain interoperability and WebAssembly smart contract execution. It connects EVM and non-EVM chains (Bitcoin, Ethereum, Solana, DASH, Hive) through validator-managed vaults, routes every liquidity pair through HBD (Hive Backed Dollar) as the base asset, and delivers feeless end-user transactions via Hive's resource credit model. Cross-chain state is validated using zero-knowledge proofs.",
+            "Magi (formerly known as VSC, Virtual Smart Chain) is a Hive-based Layer-2 protocol for cross-chain interoperability and WebAssembly smart contract execution. It currently connects Bitcoin and Ethereum on mainnet, with Litecoin, Dash, and Solana planned, through validator-managed vaults. Every liquidity pair routes through HBD (Hive Backed Dollar) as the base asset, and end-user transactions are feeless via Hive's resource credit model. Validators observe each external chain by running native clients (e.g. bitcoind, geth) and reaching BLS-signed consensus; zero-knowledge proofs are currently used for EVM (Ethereum) validation, with broader use planned for other chains.",
           details:
             'The public brand is Magi; source code lives under the GitHub organization vsc-eco. Both magi.eco and vsc.eco resolve to the same project. The canonical node is go-vsc-node (Go); the older TypeScript vsc-node is archived. Smart contracts are written in Go (TinyGo) or AssemblyScript and compile to WebAssembly. The API is exclusively GraphQL — no REST.',
           optionalLinks: [

--- a/src/content/docs/03_Native Asset Mapping.md
+++ b/src/content/docs/03_Native Asset Mapping.md
@@ -7,16 +7,16 @@ sidebar:
 
 **Native Asset Mapping** is the primary innovative feature of the Magi protocol that enables users to send and receive native assets between different blockchains wallet addresses, through Magi, reducing concerns about chain compatibility.
 
-It allows users to send, for example, **SOL from a Solana wallet to an Ethereum wallet address**. The recipient receives **native SOL**, viewable and usable on Magi when they log in with their Ethereum wallet. The received SOL tokens remain in the Magi vault on the Solana mainnet and are secured by the Magi protocol validator system. By completing the transaction, the ownership of those tokens is transferred to the account receiving the SOL. 
+It allows users to send, for example, **BTC from a Bitcoin wallet to an Ethereum wallet address**. The recipient receives **native BTC**, viewable and usable on Magi when they log in with their Ethereum wallet. The received BTC remains in the Magi vault on the Bitcoin mainnet and is secured by the Magi protocol validator system. By completing the transaction, the ownership of those tokens is transferred to the account receiving the BTC. (Litecoin, Dash, and Solana support is planned; the same flow applies to those chains once live.) 
 
 ## How It Works
 
 Native Asset Mapping links a user’s single wallet address (e.g., ETH) to their Magi account, enabling them to receive native assets from any supported blockchain even if those assets originate from a different chain than the wallet they connected.
 
-1. User connects to Magi using one wallet - for example, their Solana wallet.
-2. Sender deposits Sol tokens to Magi. Under the "transfer" option, the sender inputs the receiver’s ETH address. *(This differs from cross-chain atomic swaps, another key functionality of Magi)*
+1. User connects to Magi using one wallet - for example, their Bitcoin wallet.
+2. Sender deposits BTC to Magi. Under the "transfer" option, the sender inputs the receiver’s ETH address. *(This differs from cross-chain atomic swaps, another key functionality of Magi)*
 3. Magi maps the incoming asset to the ETH address on its internal ledger. *(Transfers within Magi incur **no direct transaction fees to users**)*
-4. The receiver logs in with their ETH wallet and sees the deposited asset (e.g., SOL).
+4. The receiver logs in with their ETH wallet and sees the deposited asset (e.g., BTC).
 5. The receiver can now **swap**, **withdraw**, or **use** the asset within Magi.
 
 ## Implications

--- a/src/content/docs/Roles/dapp-users.md
+++ b/src/content/docs/Roles/dapp-users.md
@@ -14,7 +14,7 @@ Magi dApp users benefit in key ways:
 
 - **Native asset ownership**
 - **Feeless experience**: Once assets are inside Magi, users can move and interact with them across dApps **without paying any network fees**.
-- **Interoperable UX**: A user with an ETH wallet can seamlessly interact with applications involving Bitcoin or Solana-based assets, without needing additional wallets or chains.
+- **Interoperable UX**: A user with an ETH wallet can seamlessly interact with applications involving Bitcoin-based assets (with Litecoin, Dash, and Solana planned), without needing additional wallets or chains.
 - **Secure and decentralized**: All interactions happen on-chain and are secured by the Magi validator network, eliminating reliance on centralized servers or custodians.
 
 This creates a fundamentally smoother and more powerful user experience: less friction, no need for managing multiple wallets for every single blockchain.

--- a/src/content/docs/Roles/developers.md
+++ b/src/content/docs/Roles/developers.md
@@ -6,7 +6,7 @@ sidebar:
 
 # Build Decentralized Applications (dApps) on Magi
 
-Developers on Magi gain a powerful advantage. Any application they build is instantly **interoperable with all supported blockchains**. Magi acts as a cross-chain hub which means your project isn’t siloed to one ecosystem. Instead, it's natively accessible to users from multiple chains, including Bitcoin, Ethereum, Solana, Hive and others.
+Developers on Magi gain a powerful advantage. Any application they build is instantly **interoperable with all supported blockchains**. Magi acts as a cross-chain hub which means your project isn’t siloed to one ecosystem. Instead, it's natively accessible to users from multiple chains: Bitcoin, Ethereum, and Hive are live today, with Litecoin, Dash, and Solana planned.
 
 ## Wallet Interoperability
 
@@ -18,7 +18,7 @@ Magi enables developers to build powerful decentralized applications using **Web
 
 ## Native Asset Mapping
 
-A major breakthrough for developers on Magi is **Native Asset Mapping**. This allows smart contracts to interact with native assets - such as BTC, ETH, Hive and SOL - **inside** the smart contract environment.
+A major breakthrough for developers on Magi is **Native Asset Mapping**. This allows smart contracts to interact with native assets - currently BTC, ETH, and Hive (with LTC, DASH, and SOL planned) - **inside** the smart contract environment.
 
 This capability means developers can build advanced dApps that utilize native assets seamlessly, whether it’s payments, games, DeFi tools, or even decentralized exchanges (DEXs). These applications can move and manage native assets in real time with the same ease or in many cases easier, than native tokens on a single chain.
 
@@ -30,7 +30,7 @@ What makes this even more powerful is Magi’s **zero-fee internal architecture*
 
 In short, developers can:
 
-- Use native BTC, ETH, SOL, and more directly in smart contracts  
+- Use native BTC and ETH directly in smart contracts today (with LTC, DASH, and SOL planned)  
 - Build DEXs, payment systems, and asset management tools with full native coin support  
 - Eliminate in-protocol fees, improving UX and scalability  
 

--- a/src/content/docs/Technology/Cross-Chain Arhitecture.md
+++ b/src/content/docs/Technology/Cross-Chain Arhitecture.md
@@ -12,7 +12,7 @@ This section describes how Magi interfaces with external blockchains, processes 
 Magi interfaces with external chains through a combination of:
 
 - **Blockchain light clients**  
-- **Zero-knowledge proofs (ZKPs)**  
+- **Zero-knowledge proofs (ZKPs)** — currently for Ethereum (via SP1-Helios), with broader use planned  
 - **Threshold signature schemes (TSS)**  
 
 These components enable Magi to operate trustlessly and without centralized custodians. This architecture removes the need for centralized custodians, allowing users to interact with external blockchains without relinquishing control of their assets.

--- a/src/content/docs/Technology/index.md
+++ b/src/content/docs/Technology/index.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 
-Magi's technology stack is built to enable secure, decentralized cross-chain functionality and seamless dApp development. It combines WebAssembly-based smart contracts, zero-knowledge proofs, threshold signature schemes, and decentralized vault infrastructure to support native asset interoperability with chains like Bitcoin, Ethereum, Hive, and Solana.
+Magi's technology stack is built to enable secure, decentralized cross-chain functionality and seamless dApp development. It combines WebAssembly-based smart contracts, BLS threshold signature schemes for cross-chain consensus, zero-knowledge proofs (currently for Ethereum validation, with broader use planned), and decentralized vault infrastructure to support native asset interoperability. Bitcoin, Ethereum, and Hive are live on mainnet today; Litecoin, Dash, and Solana support is planned.
 
 Validators play a central role in maintaining the network, processing transactions, securing vaults, and reaching consensus. Vaults are decentralized smart contracts that hold and manage assets from external chains with high fault tolerance and slashing-backed security.
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ sidebar:
 *This documentation provides a technical overview of Magi (Virtual Smart Chain), a decentralized protocol for cross-chain asset custody and swaps, settlement, and smart contract execution. Magi connects EVM and non-EVM chains through validator-managed vaults and a unified stablecoin-based routing system using HBD. Magi enables feeless transactions, native asset support, and composable cross-chain logic in a single trust-minimized environment.*
 
 
-Built as a high-performance, feeless settlement layer, Magi leverages **WebAssembly smart contracts**, **zero-knowledge proofs**, **validator-managed vaults** and a **collateral-backed native asset model** that reduces liquidity fragmentation across ecosystems.
+Built as a high-performance, feeless settlement layer, Magi leverages **WebAssembly smart contracts**, **BLS threshold-signature consensus**, **validator-managed vaults**, **zero-knowledge proofs** (currently for Ethereum, with broader use planned), and a **collateral-backed native asset model** that reduces liquidity fragmentation across ecosystems.
 
 All swaps are routed through a single base asset, a stablecoin, **HBD (Hive Backed Dollars). Using HBD exposes LPs only to 1-sided volatility which** makes liquidity provision on Magi **more predictable and efficient** for both institutional and retail participants.
 
@@ -18,15 +18,15 @@ Unlike other cross-chain protocols limited to basic swap mechanics, Magi support
 
 - **Native Multi-Chain Asset Support** 
 
-Assets from supported blockchains (including Bitcoin, Solana, Ethereum, and others) are deposited directly into **on-chain vaults** secured by Magi validators. These validators are required to stake **Hive** as economic collateral, ensuring security and accountability.
+Assets from supported blockchains (Bitcoin and Ethereum on mainnet today; Litecoin, Dash, and Solana planned) are deposited directly into **on-chain vaults** secured by Magi validators. These validators are required to stake **Hive** as economic collateral, ensuring security and accountability.
 
 - **Smart Contracts via WebAssembly (WASM)** 
 
 Developers can build powerful on-chain logic using WASM-based contracts, with native access to assets from multiple chains.
 
-- **Zero-Knowledge Proof Architecture** 
+- **Validator Observation & Zero-Knowledge Proofs**
 
-ZKPs are used to validate external chain interactions and maintain verifiability across systems, without compromising speed or user privacy.
+Validators observe each external chain by running native clients (e.g. `bitcoind` for Bitcoin, `geth` for Ethereum) and reach BLS-signed consensus on chain state. Zero-knowledge proofs are currently used for Ethereum validation (via the SP1-Helios light client), with broader ZK use planned for other chains.
 
 - **Universal Wallet Interoperability** 
 
@@ -42,7 +42,7 @@ Magi introduces several novel architectural components to address common limitat
 
 - **Native Asset Mapping** 
 
-Magi enables assets from different blockchains (e.g., BTC, SOL, Hive, ETH) to be securely locked on their native chains and mapped to Magi-connected addresses. For example: this allows Ethereum wallet addresses to hold native Bitcoin (BTC), Solana wallet addresses to hold native Ethereum (ETH), and vice versa, all while leveraging Magi's decentralized validator network for seamless cross-chain interoperability.
+Magi enables assets from different blockchains to be securely locked on their native chains and mapped to Magi-connected addresses. Today this covers BTC and ETH (with LTC, DASH, and SOL support planned), plus Hive as the L1. For example: this allows Ethereum wallet addresses to hold native Bitcoin (BTC) and vice versa, all while leveraging Magi's decentralized validator network for seamless cross-chain interoperability.
 
 - **Feeless In-Protocol Transactions** 
 

--- a/src/content/docs/using-vsc.md
+++ b/src/content/docs/using-vsc.md
@@ -14,11 +14,11 @@ sidebar:
 
 Liquidity pools are collections of two or more assets (tokens) that are locked into a smart contract. These pools are used by **Automated Market Makers (AMMs)** to facilitate decentralized trading and ensure liquidity for the users interacting with the protocol.
 
-In Magi, liquidity pools are designed to pair a volatile asset (such as Bitcoin, Ethereum, Solana…) with a stable asset: **HBD (Hive Backed Dollars)**. This structure is intended to manage the risk of volatility in liquidity provision, making it more predictable for users providing liquidity.
+In Magi, liquidity pools are designed to pair a volatile asset (such as Bitcoin or Ethereum today, with Litecoin, Dash, and Solana planned) with a stable asset: **HBD (Hive Backed Dollars)**. This structure is intended to manage the risk of volatility in liquidity provision, making it more predictable for users providing liquidity.
 
 ## LP Creation and Pairing
 
-Every liquidity pool on Magi involves pairing a volatile asset (like BTC, ETH, SOL) with **HBD**. For instance, a **BTC/HBD** liquidity pool would contain both BTC and HBD tokens. By providing liquidity to this pool, liquidity providers (LPs) deposit equal values of both assets (e.g., an amount of BTC and an equivalent amount of HBD) into the pool.
+Every liquidity pool on Magi involves pairing a volatile asset (like BTC or ETH; LTC, DASH, and SOL planned) with **HBD**. For instance, a **BTC/HBD** liquidity pool would contain both BTC and HBD tokens. By providing liquidity to this pool, liquidity providers (LPs) deposit equal values of both assets (e.g., an amount of BTC and an equivalent amount of HBD) into the pool.
 
 ## The Role of HBD
 


### PR DESCRIPTION
## What
Updates docs (and the llms.txt description in astro.config.mjs) to match
what's actually in the go-vsc-node codebase. Eight files, all small
wording corrections.

## Why
@lordbutterfly flagged that current docs overstate ZK proofs and list
Solana as supported when it isn't yet. Verified against the codebase:

- modules/oracle/chain/ contains bitcoin.go, ethereum.go, dash.go,
  litecoin.go — no solana.go
- modules/common/system-config/system-config.go: only BTC and ETH
  have deployed mapping contracts on mainnet
- modules/oracle/chain/chain_relay.go: validation mechanism is BLS-
  signed consensus over native node observation, not ZK proofs
- ZK in code: cmd/zk-tx-signer (SP1-Helios prover sidecar for ETH)
  and modules/wasm/sdk/sp1_verifier.go (contract-level SDK helper)

## Files changed
- astro.config.mjs (llms.txt description)
- src/content/docs/index.mdx (4 corrections)
- src/content/docs/Technology/index.md
- src/content/docs/Technology/Cross-Chain Arhitecture.md
- src/content/docs/03_Native Asset Mapping.md (rewrite SOL examples as BTC)
- src/content/docs/Roles/dapp-users.md
- src/content/docs/Roles/developers.md (3 corrections)
- src/content/docs/using-vsc.md (2 corrections)

Status framing throughout: live = Bitcoin, Ethereum, Hive.
Planned = Litecoin, Dash, Solana.

## Verification
- pnpm run build produces dist/llms.txt with the corrected description
- After deploy: curl https://docs.magi.eco/llms.txt should reflect the new wording